### PR TITLE
T2H-101 ui subscription module

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,7 @@ class User {
 const user = new User();
 
 //create an instance of the syncosaurus class, known as a client
-const r = new Syncosaurus({
+const synco = new Syncosaurus({
   mutators,
   userID: user.id,
 });
@@ -24,18 +24,18 @@ const incrementKey = 'count';
 
 function App() {
   const handleIncrementClick = () => {
-    r.mutate.increment({ key: incrementKey, delta: 1 });
+    synco.mutate.increment({ key: incrementKey, delta: 1 });
   };
 
   const handleDecrementClick = () => {
-    r.mutate.decrement({ key: incrementKey, delta: 1 });
+    synco.mutate.decrement({ key: incrementKey, delta: 1 });
   };
 
-  const cache = useSubscribe(r, incrementKey, { [incrementKey]: 0 });
+  const count = useSubscribe(synco, (tx) => tx.get(incrementKey), 0);
 
   return (
     <div>
-      <div>{cache[incrementKey]}</div>
+      <div>{count}</div>
       <button onClick={handleIncrementClick}>GROW</button>
       <button onClick={handleDecrementClick}>SHRINK</button>
     </div>

--- a/frontend/src/utils/transactions.js
+++ b/frontend/src/utils/transactions.js
@@ -3,29 +3,52 @@ import { monotonicFactory } from 'ulidx';
 const ulid = monotonicFactory();
 
 export class Transaction {
-  constructor(localState, notify, mutator, args, reason) {
+  constructor(localState, mutator, args, keysAccessed) {
     this.id = ulid(Date.now());
     this.localState = localState;
-    this.notify = notify;
     this.mutator = mutator;
     this.mutatorArgs = args;
-    this.reason = reason;
+    this.keysAccessed = keysAccessed;
   }
 
   get(key) {
+    this.keysAccessed[key] = true;
     return this.localState[key];
   }
 
   set(key, value) {
-    if (this.reason === 'initial') {
-      this.localState[key] = value; //update local KV
-      this.notify(key, { ...this.localState }); //alert subscribers of change
-    } else if (this.reason === 'replay') {
-      this.localState[key] = value; //update local KV
-    }
+    this.localState[key] = value; //update local KV
+    this.keysAccessed[key] = true;
   }
 
   delete(key) {
     delete this.localState[key];
+    this.keysAccessed[key] = true;
   }
+}
+
+export class QueryTransaction {
+  constructor(localState, keysAccessed) {
+    this.localState = localState;
+    this.keysAccessed = keysAccessed;
+  }
+  //get - returns the value for the key
+  get(key) {
+    this.keysAccessed[key] = true;
+    return this.localState[key];
+  }
+
+  //has - returns true if the key exists
+  has(key) {
+    this.keysAccessed[key] = true;
+    return Object.hasOwn(this.localState, key);
+  }
+
+  //isEmpty - returns true if the state is empty
+  isEmpty() {
+    return Object.keys(this.localState).length === 0;
+  }
+
+  //scan - to be implemented later, but returns an iterator, 
+  //useful for getting or mutating multiple keys based on some criteria
 }


### PR DESCRIPTION
### Update Overview
The subscription methods (`subscribe`, `unsubscribe` and `notify`) were updated to be more flexible when used on the front end. They now support passing in a "query" which is a function that can be comprised of three read-only methods (`get`, `has`, and `isEmpty`) to get and transform data from local storage before it is rendered by the React components, e.g.:
```javascript
(tx) => tx.get('count')
```
When the query is run, a key "watchlist" called `keys` is generated so that each time any of those same keys in the watchlist are updated in the local key-value store (either via local mutation or server updates), the callbacks which re-render the UI are invoked. 

### Subscription Updates
Here is a short description of the three modified subscription methods on the `Syncosaurus` class which relate to the `subscriptions` array:
- `subscribe`: used to store the aforementioned key watchlist, a query, the previous value the last time the query was run, and a callback (`(newData) => setData(newData)`) created by the  `useSubscribe` custom hook in the `subscription` array. Here is the shape of an example `subscription` array with some commentary:
```javascript
 [
    {
      keys: { //this KV pair demonstrates one subscription query that depends on a single key
        key1: true
      }
      query: this is the actual query function that gets the data from keys and returns a value
      previousResultOfQuery: this is the result of the previous time running the query
      callback: This is just a simple useState which sets the state to the result of running the query in order to re-render the UI
    },
    { 
      keys: { //this KV pair demonstrates one subscription query that depends on a range of keys or multiple keys
        key1: true, 
        key2: true,
        key3: true,
      }
      query: this is the actual query function that gets the data from keys and returns a value
      previousResultOfQuery: this is the result of the previous time running the query
      callback: This is just a simple useState which sets the state to the result of running query in order to re-render the UI
    }
  ]
```
- `unsubscribe`: function that is invoked in a callback to remove the the subscription from the subscriptions array when the component dependent on the subscription (the "subscriber") is unmounted:
```javascript
() => {
      this.unsubscribe(query);
};
```

- `notify`: function that takes a list of keys and scans through the subscribers for each key so that it can notify the appropriate subscribers. A couple optimizations were baked into this logic:
 -- subscribers are not notified twice if they depend on multiple keys, which cuts down on unnecessary re-renders
 -- subscribers are not notified if the query result has not changed since the last time, which cuts down on unnecessary re-renders

### Transaction Updates
In order to accommodate the more flexible subscription model, a new class called `queryTransaction` class was created. The class defines the aforementioned methods:
- `get(key)`: returns the value for a given key in the local store
- `has(key)`: returns `true` if the key exists in the local store
- `isEmpty()`: returns `true` if the entire local store is empty

These methods can be used inside of a query and also keeps track of keys executed when these methods are invoked. This allows us to create a comprehensive list keys of keys that a query depends on. As mentioned above, this set of keys is used to determine when to re-render the UI by storing the set in the `subscription` array which is then accessed by the `notify` method to determine if the subscribers should be notified.

### `App.jsx` Updates
`App.jsx` was updated to use a query instead of a single property name when invoking `useSubscribe`

### Further Development
- Implement `has` and `isEmpty` on the transaction class
- Add a `scan` method to both transaction classes (`Transaction` and `QueryTransaction`) which returns a set of keys with common traits
- Combine the `Transaction` and `QueryTransaction` classes in some kind of inheritance structure since they share a lot of overlapping code
- If the subscription module becomes a bottleneck, we can find ways to optimize to make it quicker
