### PR TITLE
T2H-111 additional read-only methods for transaction class

### DIFF
--- a/syncosaurus/syncosaurus.js
+++ b/syncosaurus/syncosaurus.js
@@ -1,4 +1,4 @@
-import { Transaction, QueryTransaction } from './transactions';
+import { WriteTransaction, ReadTransaction } from './transactions';
 
 export default class Syncosaurus {
   constructor(options) {
@@ -75,7 +75,7 @@ export default class Syncosaurus {
     for (let mutator in mutators) {
       this.mutate[mutator] = args => {
         let subKeys = {};
-        const transaction = new Transaction(
+        const transaction = new WriteTransaction(
           this.localState,
           mutator,
           args,
@@ -98,7 +98,7 @@ export default class Syncosaurus {
 
       this.replayMutate[mutator] = args => {
         let subKeys = {};
-        const transaction = new Transaction(
+        const transaction = new WriteTransaction(
           this.localState,
           mutator,
           args,
@@ -113,7 +113,7 @@ export default class Syncosaurus {
 
   subscribe(query, callback) {
     let subKeys = {};
-    let queryTransaction = new QueryTransaction(this.localState, subKeys);
+    let queryTransaction = new ReadTransaction(this.localState, subKeys);
     let queryResult = query(queryTransaction);
     let subscriptionInfo = {
       keys: subKeys,
@@ -154,7 +154,7 @@ export default class Syncosaurus {
           !executedSubscriptions[subIdx]
         ) {
           let newSubKeys = {};
-          let queryTransaction = new QueryTransaction(
+          let queryTransaction = new ReadTransaction(
             this.localState,
             newSubKeys
           );

--- a/syncosaurus/transactions.js
+++ b/syncosaurus/transactions.js
@@ -2,53 +2,50 @@ import { monotonicFactory } from 'ulidx';
 
 const ulid = monotonicFactory();
 
-export class Transaction {
-  constructor(localState, mutator, args, keysAccessed) {
-    this.id = ulid(Date.now());
-    this.localState = localState;
-    this.mutator = mutator;
-    this.mutatorArgs = args;
-    this.keysAccessed = keysAccessed;
-  }
-
-  get(key) {
-    this.keysAccessed[key] = true;
-    return this.localState[key];
-  }
-
-  set(key, value) {
-    this.localState[key] = value; //update local KV
-    this.keysAccessed[key] = true;
-  }
-
-  delete(key) {
-    delete this.localState[key];
-    this.keysAccessed[key] = true;
-  }
-}
-
-export class QueryTransaction {
+export class ReadTransaction {
   constructor(localState, keysAccessed) {
     this.localState = localState;
     this.keysAccessed = keysAccessed;
   }
-  //get - returns the value for the key
+
+  //returns the value for the key from local store
   get(key) {
     this.keysAccessed[key] = true;
     return this.localState[key];
   }
 
-  //has - returns true if the key exists
+  //returns true if the key exists in local store
   has(key) {
     this.keysAccessed[key] = true;
     return Object.hasOwn(this.localState, key);
   }
 
-  //isEmpty - returns true if the state is empty
+  //returns true if the local store is empty
   isEmpty() {
     return Object.keys(this.localState).length === 0;
   }
 
-  //scan - to be implemented later, but returns an iterator, 
+  //scan - to be implemented later, but returns an iterator, which is
   //useful for getting or mutating multiple keys based on some criteria
+}
+
+export class WriteTransaction extends ReadTransaction {
+  constructor(localState, mutator, args, keysAccessed) {
+    super(localState, keysAccessed);
+    this.id = ulid(Date.now());
+    this.mutator = mutator;
+    this.mutatorArgs = args;
+  }
+
+  //update value of provided key in local store
+  set(key, value) {
+    this.localState[key] = value;
+    this.keysAccessed[key] = true;
+  }
+
+  //delete given key from local store
+  delete(key) {
+    delete this.localState[key];
+    this.keysAccessed[key] = true;
+  }
 }


### PR DESCRIPTION
### Updates
- Updated the `Transaction` class to have access to the `has` and `isEmpty` class by making the `Transaction` class inherit from the `QueryTransaction` class
- Renamed the `Transaction` class to `WriteTransaction` and renamed the `QueryTransacation` class to `ReadTransaction`
- Updated `synosaurus` class to use new names

### Testing
- I tested both demos (`counter` and `presence`) to ensure that they were still working