### PR TITLE
t2h 134 add read-only methods to backend ServerTransaction class

### DIFF
--- a/do-server/src/index.mjs
+++ b/do-server/src/index.mjs
@@ -14,6 +14,14 @@ class ServerTransaction {
     return this.canon[key];
   }
 
+  has(key) {
+    return Object.hasOwn(this.canon, key);
+  }
+
+  isEmpty() {
+    return Object.keys(this.canon).length === 0;
+  }
+
   set(key, value) {
     this.canon[key] = value;
 


### PR DESCRIPTION
### Update
Added read-only methods `has` and `isEmpty` to the `ServerTransaction` class on the backend to match the frontend SDK

### Testing
Added `has` and `isEmpty` to mutators and then saw same results on frontend and backend

