### PR TITLE
feat: Added encryption functionality with attached KV store

### DIFF
--- a/demo-apps/counter/index.html
+++ b/demo-apps/counter/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/demo-apps/counter/src/components/App.jsx
+++ b/demo-apps/counter/src/components/App.jsx
@@ -1,30 +1,38 @@
 import '../assets/App.css';
 import { Counter } from './counter';
-import { mockDatabase } from '../services/mockDatabase';
+// import { mockDatabase } from '../services/mockDatabase';
 import { useState, useEffect } from 'react';
 
+const baseURL = "http://localhost:8787";
+
 function App() {
-  const [roomsAndRoomIDs, setRoomsAndRoomIDs] = useState(null);
+  const [encryptedRoomNameList, setEncryptedRoomNameList] = useState([]);
   const [selectedRoom, setSelectedRoom] = useState(null);
 
   useEffect(() => {
-    (async () => {
-      setRoomsAndRoomIDs(await mockDatabase.getAllRooms());
-    })();
+    const fetchList = async () => {
+      const response = await fetch(`${baseURL}/syncosaurus`);
+      const { encryptedRoomNameList: list } = await response.json();
+
+      setEncryptedRoomNameList(list);
+    };
+
+    fetchList();
   }, []);
 
-  const handleButtonClick = event => {
-    const room = event.target.innerText;
-    setSelectedRoom(room);
+  const handleButtonClick = async (e, roomName) => {
+    e.preventDefault();
+
+    setSelectedRoom(roomName);
   };
 
   return (
     <div>
-      {roomsAndRoomIDs ? (
-        Object.keys(roomsAndRoomIDs).map(room => {
+      {encryptedRoomNameList.length ? (
+        encryptedRoomNameList.map(roomName => {
           return (
-            <button key={room} onClick={handleButtonClick}>
-              {room}
+            <button key={roomName} onClick={(e) => handleButtonClick(e, roomName)}>
+              {roomName}
             </button>
           );
         })
@@ -32,7 +40,7 @@ function App() {
         <p>Loading...</p>
       )}
       {selectedRoom && (
-        <Counter roomID={roomsAndRoomIDs[selectedRoom]} room={selectedRoom} />
+        <Counter roomID={selectedRoom}/>
       )}
     </div>
   );

--- a/demo-apps/counter/src/components/counter.jsx
+++ b/demo-apps/counter/src/components/counter.jsx
@@ -13,7 +13,7 @@ const synco = new Syncosaurus({
   userID: user.id,
 });
 
-export const Counter = ({ roomID, room }) => {
+export const Counter = ({ roomID }) => {
   // create an instance of the syncosaurus class, known as a client
   if (synco.roomID !== roomID || !synco.hasLiveWebsocket()) {
     synco.launch(roomID);
@@ -31,7 +31,6 @@ export const Counter = ({ roomID, room }) => {
 
   return (
     <div>
-      <div>Current room: {room}</div>
       <div>{count}</div>
       <button onClick={handleIncrementClick}>GROW</button>
       <button onClick={handleDecrementClick}>SHRINK</button>

--- a/do-server/src/encrypt.js
+++ b/do-server/src/encrypt.js
@@ -1,0 +1,72 @@
+import { Buffer } from 'node:buffer';
+
+const encryptSymmetric = async (plaintext, key) => {
+	// create a random 96-bit initialization vector (IV)
+	const iv = crypto.getRandomValues(new Uint8Array(12));
+
+	// encode the text you want to encrypt
+	const encodedPlaintext = new TextEncoder().encode(plaintext);
+
+	// prepare the secret key for encryption
+	const secretKey = await crypto.subtle.importKey(
+		'raw',
+		Buffer.from(key, 'base64'),
+		{
+			name: 'AES-GCM',
+			length: 256,
+		},
+		true,
+		['encrypt', 'decrypt']
+	);
+
+	// encrypt the text with the secret key
+	const ciphertext = await crypto.subtle.encrypt(
+		{
+			name: 'AES-GCM',
+			iv,
+		},
+		secretKey,
+		encodedPlaintext
+	);
+
+	// return the encrypted text "ciphertext" and the IV
+	// encoded in base64
+	return {
+		ciphertext: Buffer.from(ciphertext).toString('base64'),
+		iv: Buffer.from(iv).toString('base64'),
+	};
+};
+
+const decryptSymmetric = async (ciphertext, iv, key) => {
+	// prepare the secret key
+	const secretKey = await crypto.subtle.importKey(
+		'raw',
+		Buffer.from(key, 'base64'),
+		{
+			name: 'AES-GCM',
+			length: 256,
+		},
+		true,
+		['encrypt', 'decrypt']
+	);
+
+	// decrypt the encrypted text "ciphertext" with the secret key and IV
+	const cleartext = await crypto.subtle.decrypt(
+		{
+			name: 'AES-GCM',
+			iv: Buffer.from(iv, 'base64'),
+		},
+		secretKey,
+		Buffer.from(ciphertext, 'base64')
+	);
+
+	// decode the text and return it
+	return new TextDecoder().decode(cleartext);
+};
+
+// create or bring your own base64-encoded encryption key
+const generateKey = () => {
+	return Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString('base64');
+};
+
+export { encryptSymmetric, decryptSymmetric, generateKey };

--- a/do-server/src/index.mjs
+++ b/do-server/src/index.mjs
@@ -43,15 +43,84 @@ class ServerTransaction {
 }
 
 // Worker
-export default {
-  async fetch(request, env) {
-    const roomID = request.url.split('/room/').at(-1);
-    // This example refers to the same Durable Object instance since it hardcodes the name "foo".
-    let id = env.WEBSOCKET_SERVER.idFromName(roomID);
-    let stub = env.WEBSOCKET_SERVER.get(id);
+// Worker with Basic Room Encryption
+// Test Entry:
+// decryptionKey:  nDvnwoq/qrKCkBaXdHQ0riiXsT/80IrHmyiLqMeVYR4=
+// ciphertext:  b6BUmmtioZh3Mm14q7pXAijuYQ==
+// iv:  QHxgUtqF6PAPhiaQ
+// decrypted text: foo
 
-    return await stub.fetch(request);
-  },
+// current room URL shape: `http://my-collab-app.com/room/encryptedRoomID`
+// excalidraw live session room URL shape: `http://my-collab-app.com/#room=encryptedRoomID`
+
+// these eventually will be cloudflare env variables
+const allowedOrigin = 'http://localhost:5173';
+const KV_NAMESPACE = 'room_keys_2';
+
+export default {
+	async fetch(request, env) {
+		const { encryptSymmetric, decryptSymmetric, generateKey } = await import('./encrypt.js');
+		let response;
+
+		if (request.method === 'OPTIONS') {
+			return new Response(null, {
+				status: 204,
+				headers: {
+					'Access-Control-Allow-Credentials': 'true',
+					'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+					'Access-Control-Allow-Origin': allowedOrigin,
+					'Access-Control-Allow-Headers': 'Content-Type',
+				},
+			});
+		}
+
+		if (request.url.endsWith('syncosaurus') && request.method === 'POST') {
+			const { newRoomName } = await request.json();
+			const key = generateKey();
+			const { ciphertext: encryptedRoomName, iv } = await encryptSymmetric(newRoomName, key);
+
+			await env[KV_NAMESPACE].put(encryptedRoomName, JSON.stringify({ key, iv }));
+			console.log(`'${encryptedRoomName}': ${await env[KV_NAMESPACE].get(encryptedRoomName)}`);
+			response = Response.json({ encryptedRoomName });
+			response.headers.set('Access-Control-Allow-Origin', allowedOrigin);
+			response.headers.set('Access-Control-Allow-Credentials', 'true');
+
+			return response;
+		}
+
+		if (request.url.endsWith('syncosaurus') && request.method === 'GET') {
+			const { keys } = await env[KV_NAMESPACE].list();
+			const encryptedRoomNameList = keys.map(({ name }) => name);
+
+			response = Response.json({ encryptedRoomNameList });
+			response.headers.set('Access-Control-Allow-Origin', allowedOrigin);
+			response.headers.set('Access-Control-Allow-Credentials', 'true');
+
+			return response;
+		}
+
+		const splitRoomsArr = (new URL(request.url)).pathname.split('room/');
+		if (splitRoomsArr.length === 1) {
+			return new Response(`Invalid Room URL: ${request.url}`, { status: 500 });
+		}
+
+		const encryptedRoomName = splitRoomsArr.at(-1);
+		const encryptedRoomNameValue = await env[KV_NAMESPACE].get(encryptedRoomName);
+    // console.log(await env[KV_NAMESPACE].list());
+
+		if (encryptedRoomNameValue) {
+			const { key, iv } = JSON.parse(encryptedRoomNameValue);
+			const decryptedRoomName = await decryptSymmetric(encryptedRoomName, iv, key);
+			console.log(`RoomID found for encrypted string '${encryptedRoomName}': ${decryptedRoomName}`);
+
+			const id = env.WEBSOCKET_SERVER.idFromName(decryptedRoomName);
+			const stub = env.WEBSOCKET_SERVER.get(id);
+			return await stub.fetch(request);
+		} else {
+			console.log(`The encrypted room '${encryptedRoomName}' does not correspond to any room names`);
+			return new Response(`URL ${request.url} can not be found.`, { status: 404 });
+		}
+	},
 };
 
 // Durable Object

--- a/do-server/wrangler.toml
+++ b/do-server/wrangler.toml
@@ -1,6 +1,11 @@
 name = "websocket-server"
 main = "./src/index.mjs"
 compatibility_date = "2022-09-08"
+compatibility_flags = [ "nodejs_compat" ]
+
+kv_namespaces = [
+  { binding = "room_keys_2", id = "f4b7aaa8a9004a5d93de42b84afa89af" }
+]
 
 [[durable_objects.bindings]]
 name = "WEBSOCKET_SERVER"

--- a/syncosaurus/syncosaurus.js
+++ b/syncosaurus/syncosaurus.js
@@ -115,12 +115,21 @@ export default class Syncosaurus {
     return this.socket.readyState === 0 || this.socket.readyState === 1;
   }
 
-  initalizeWebsocket() {
+  async initalizeWebsocket() {
     // establish websocket connection with DO
     this.socket = new WebSocket(`${roomUriPrefix}/${this.roomID}`);
 
+    // wait for socket to open before accepting messages
+    this.socket.addEventListener('open', () => {
+      this.socket.send(JSON.stringify({ init: true, clientID: this.userID }));
+    });
+
     //When message received from websocket, update canon state and re-run pending mutations
     this.socket.addEventListener('message', event => {
+      if (!this.hasLiveWebsocket()) {
+        return;
+      }
+
       //parse websocket response
       const {
         updateType,
@@ -146,7 +155,8 @@ export default class Syncosaurus {
         //check to see if reset is needed because we are missing one delta
       } else if (
         updateType === 'delta' &&
-        snapshotID - this.prevServerSnapshot > 1
+        snapshotID - this.prevServerSnapshot > 1 &&
+        this.socket.readyState === 1
       ) {
         this.socket.send(JSON.stringify({ reset: true }));
         //no need to apply update locally because it will be encompassed when next init arrives
@@ -187,10 +197,6 @@ export default class Syncosaurus {
         delete presence[this.userID];
         this.presenceConnection(presence);
       }
-    });
-
-    this.socket.addEventListener('open', () => {
-      this.socket.send(JSON.stringify({ init: true, clientID: this.userID }));
     });
   }
 


### PR DESCRIPTION
- Introduce an encryption module located in `do-server/src/encrypt.js` using [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)  
  - Encryption functionality only applies to room IDs at this point, can and should be applied to other sensitive identifiers as well 
- Integrate KV store for encrypted strings and their associated decryption key and IV value
  - Entries have a key of the encrypted string, and a value of a JSONified string with two key-value pairs - one for the decryption key and the other for the IV value, which is also needed for decryption.
  - KV store's data is local only at this time
  - Per Rodney's suggestion, user-facing identifiers that are more readable and user-friendly can potentially also be stored in the KV store
- Update Counter demo app to utilize encryption module 
- Update do-server worker code in `do-server/src/index.mjs` to screen for valid encrypted room names in request urls 
- Update `syncosaurus/syncosaurus.js`, line 159, to account for websocket in connecting state before sending reset delta
