### PR TITLE
T2 h 156 proactive error handling

### DIFF
--- a/syncosaurus/syncosaurus.js
+++ b/syncosaurus/syncosaurus.js
@@ -3,6 +3,10 @@ const roomUriPrefix = 'ws://localhost:8787/websocket/room';
 
 export default class Syncosaurus {
   constructor(options) {
+    if (!options.userID) {
+      throw new Error('userID must be provided when instantiating Syncosaurus');
+    }
+
     //create client side KV stores
     this.localState = {}; //create a KV store instance for the syncosaurus client that serves as UI display
     this.txQueue = []; // create a tx
@@ -93,6 +97,10 @@ export default class Syncosaurus {
   }
 
   launch(roomID) {
+    if (!roomID) {
+      throw new Error('roomID must be provided when launching Syncosaurus');
+    }
+
     this.setRoomID(roomID);
     this.initalizeWebsocket();
     this.initalizeMutators();

--- a/syncosaurus/transactions.js
+++ b/syncosaurus/transactions.js
@@ -12,7 +12,12 @@ export class ReadTransaction {
   //returns the value for the key from local store
   get(key) {
     this.keysAccessed[key] = true;
-    return this.localState[key];
+
+    if (this.localState[key] === undefined) {
+      return undefined;
+    } else {
+      return JSON.parse(JSON.stringify(this.localState[key]));
+    }
   }
 
   //returns true if the key exists in local store
@@ -30,9 +35,11 @@ export class ReadTransaction {
   scan(kvCallback) {
     let scanReturn = {};
 
-    for (let key in this.localState) {
-      if (kvCallback(key, this.localState[key])) {
-        scanReturn[key] = this.localState[key];
+    const localStateCopy = JSON.parse(JSON.stringify(this.localState));
+
+    for (let key in localStateCopy) {
+      if (kvCallback(key, localStateCopy[key])) {
+        scanReturn[key] = localStateCopy[key];
       }
     }
 


### PR DESCRIPTION
1. Put two guard clauses in `syncosaurus` class:
    - make sure `RoomID` is provided on instantiation
    - make sure `clientID` is provided on launch

2. Changed the read-only methods `get` and `scan` on the `ReadTransaction` class to return copies of local KV store so that developers don't accidentally mutate values when reading from it in subscription queries or mutators
