### PR TITLE
T2 h 144 time interval storage, Durable Object env variables

### DIFF
--- a/do/index.mjs
+++ b/do/index.mjs
@@ -96,7 +96,6 @@ export default {
 // Durable Object
 export class WebSocketServer {
   constructor(state, env) {
-    console.log('making a new one');
     this.MSG_FREQUENCY = env.MSG_FREQUENCY;
     this.mutators = mutators;
     this.state = state;
@@ -107,7 +106,7 @@ export class WebSocketServer {
     this.currentSnapshotID = 0;
     this.patch = [];
     this.presence = {};
-    this.canon = this.storage.get('canon') || {};
+    this.canon = {};
 
     this.messageInterval = setInterval(
       () =>
@@ -130,14 +129,18 @@ export class WebSocketServer {
     );
 
     if (env.USE_STORAGE) {
-      console.log('using storage');
+      this.loadStorage();
       this.autosaveInterval = setInterval(() => {
+        this.storage.put('canon', { ...this.canon });
         console.log('autosaving');
-        this.storage.put('canon', this.canon);
       }, env.AUTOSAVE_INTERVAL);
     } else {
       console.log('not using storage');
     }
+  }
+
+  async loadStorage() {
+    this.canon = await this.storage.get('canon');
   }
 
   broadcast(data) {

--- a/do/index.mjs
+++ b/do/index.mjs
@@ -142,6 +142,9 @@ export class WebSocketServer {
 
   async loadStorage() {
     this.canon = await this.storage.get('canon');
+    if (this.canon === undefined) {
+      this.canon = {};
+    }
   }
 
   broadcast(data) {

--- a/do/index.mjs
+++ b/do/index.mjs
@@ -128,6 +128,7 @@ export class WebSocketServer {
       this.MSG_FREQUENCY
     );
 
+    // Conditional check for storage dependent logic
     if (env.USE_STORAGE) {
       this.loadStorage();
       this.autosaveInterval = setInterval(() => {
@@ -217,6 +218,12 @@ export class WebSocketServer {
 
     server.addEventListener('close', async cls => {
       this.connections = this.connections.filter(ws => ws !== server);
+
+      if (this.autosaveInterval && this.connections.length === 0) {
+        // This executes if autosave is in use, and the just disconnected WS is the last one
+        console.log('Last websocket disconnected. Saving state.');
+        this.storage.put('canon', { ...this.canon });
+      }
       delete this.presence[server.clientID];
     });
 

--- a/do/wrangler.toml
+++ b/do/wrangler.toml
@@ -15,4 +15,4 @@ new_classes = ["WebSocketServer"]
 ALLOWED_ORIGIN = "http://localhost:5173"
 USE_STORAGE = true
 MSG_FREQUENCY = 16
-AUTOSAVE_INTERVAL = 1000
+AUTOSAVE_INTERVAL = 30000

--- a/do/wrangler.toml
+++ b/do/wrangler.toml
@@ -10,3 +10,9 @@ class_name = "WebSocketServer"
 [[migrations]]
 tag = "v1"
 new_classes = ["WebSocketServer"]
+
+[vars]
+ALLOWED_ORIGIN = "http://localhost:5173"
+USE_STORAGE = true
+MSG_FREQUENCY = 16
+AUTOSAVE_INTERVAL = 1000


### PR DESCRIPTION
The DOs now have transactional storage again (it was previously removed for ease of development).

There is now an environment variable, configured in `syncosaurus.json` and copied into `wrangler.toml` by the CLI, to allow the developer to choose weather or not to use transactional storage, and persist data between instances of a durable object. Particularly in development, this can be very convenient to disable, so that every restart gives you a fresh DO to work with.

There is a conditional check inside the constructor which only runs if the env variable is set to true. When it does execute, the constructor loads the previous `canon` state from storage (if it exists), and saves it to the server. Also, an autosave interval is set up to periodically save `canon` state into persistent storage. This time interval is also configured through the `syncosaurus.json` config file.

Additionally, there is an additional conditional check added in the `close` event handler for each websocket connection. When a websocket closes, it checks if it is the last connection on the DO (`this.connections` will have 0 length). If so, then one last call to `this.storage.put` saves the final `canon` state into persistent storage, before the durable object instance is spun down. 

Lastly, the last of the hardcoded paths were extracted to environment variables; also all configured through `syncosaurus.json`.