### PR TITLE
fix: implemented several fixes in `utils.js` for synco constructor va…

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,6 +1,5 @@
 // error validation here
 import { parse } from 'acorn';
-import mutators from '../../do/mutators';
 
 const validateUrl = url => {
   try {
@@ -19,7 +18,7 @@ const validateMutators = mutators => {
   for (let mutator in mutators) {
     const paramArr = parse(mutators[mutator], {
       ecmaVersion: 14,
-    }).body[0].params.map(param => param.name);
+    }).body[0].expression.params.map(param => param.name);
 
     if (!(mutators[mutator] instanceof Function) || !paramArr.includes('tx')) {
       return false;
@@ -36,7 +35,7 @@ const validateSyncosaurusOptions = options => {
     );
   } else if (!validateUrl(options.server)) {
     throw new Error(`The server URL '${options.server} is not valid`);
-  } else if (!validateMutators(mutators)) {
+  } else if (!validateMutators(options.mutators)) {
     throw new Error(
       "Mutators must all be functions, and all must have 'tx' as their first parameter"
     );


### PR DESCRIPTION
All changes in `utils/utils.js`

- removed erroneous, unnecessary top-level 'mutators' import - mutators are passed as an argument to the fn itself
- fixed de-referenced mutators variable on line 38: this should be a key of the argument 'options'
- erroneous `params` missing keys on line 21. That key is one level deeper, as a property of the `expression` key of `body[0]`