### PR TITLE
Alter validateMutator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "syncosaurus",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syncosaurus",
-      "version": "0.0.6",
+      "version": "0.0.10",
       "license": "ISC",
       "dependencies": {
-        "acorn": "^8.11.3",
         "nanoid": "^5.0.6",
         "ulidx": "^2.3.0"
       },
@@ -549,6 +548,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncosaurus",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A framework for adding realtime, collaborative features to React applications.",
   "type": "module",
   "exports": "./index.js",
@@ -36,9 +36,8 @@
   },
   "homepage": "https://github.com/syncosaurus/syncosaurus#readme",
   "dependencies": {
-    "ulidx": "^2.3.0",
-    "acorn": "^8.11.3",
-    "nanoid": "^5.0.6"
+    "nanoid": "^5.0.6",
+    "ulidx": "^2.3.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syncosaurus",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "description": "A framework for adding realtime, collaborative features to React applications.",
   "type": "module",
   "exports": "./index.js",

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,5 +1,4 @@
 // error validation here
-import { parse } from 'acorn';
 
 const validateUrl = url => {
   try {
@@ -16,11 +15,7 @@ const validateMutators = mutators => {
   }
 
   for (let mutator in mutators) {
-    const paramArr = parse(mutators[mutator], {
-      ecmaVersion: 14,
-    }).body[0].expression.params.map(param => param.name);
-
-    if (!(mutators[mutator] instanceof Function) || !paramArr.includes('tx')) {
+    if (!(mutators[mutator] instanceof Function)) {
       return false;
     }
   }


### PR DESCRIPTION
I found an interesting bug while deploying to Cloudflare pages. I don't think I'd have ever thought of this without running into the bug directly. 

<img width="701" alt="image" src="https://github.com/syncosaurus/syncosaurus/assets/110345733/e553016f-cfe0-4489-abc9-f3c4846c1743">

There was an issue with `validateMutators` when the app is deployed to Cloudflare Pages. When CF deploys, it also minifies all the js files, and the `tx` param in mutators gets renamed (in this case to just `e`). This causes the validation function to throw an error, as it's looking specifically for a param called `tx`.

I've removed that block of code in this PR. Having run into this bug, Now I'm thinking that the name of the parameter isn't something that should be enforced in the validator. If we migrate to TypeScript then we could have more robust checking to ensure that mutators receive a `tx` argument. I do think having the check that all mutators are functions is still very helpful to have, so I've just modified the code to leave that one in.

